### PR TITLE
Restore canView check for image shortcodes

### DIFF
--- a/filesystem/File.php
+++ b/filesystem/File.php
@@ -214,28 +214,11 @@ class File extends DataObject implements ShortcodeHandler, AssetContainer {
 	 * @return string Result of the handled shortcode
 	 */
 	public static function handle_shortcode($arguments, $content, $parser, $shortcode, $extra = array()) {
-		if(!isset($arguments['id']) || !is_numeric($arguments['id'])) {
-			return null;
-		}
-
-		/** @var File|SiteTree $record */
-		$record = DataObject::get_by_id('File', $arguments['id']);
-
-		// Check record for common errors
-		$errorCode = null;
-		if (!$record) {
-			$errorCode = 404;
-		} elseif(!$record->canView()) {
-			$errorCode = 403;
-		}
+		// Find appropriate record, with fallback for error handlers
+		$record = static::find_shortcode_record($arguments, $errorCode);
 		if($errorCode) {
-			$result = static::singleton()->invokeWithExtensions('getErrorRecordFor', $errorCode);
-			$result = array_filter($result);
-			if($result) {
-				$record = reset($result);
-			}
+			$record = static::find_error_record($errorCode);
 		}
-
 		if (!$record) {
 			return null; // There were no suitable matches at all.
 		}
@@ -258,6 +241,52 @@ class File extends DataObject implements ShortcodeHandler, AssetContainer {
 		} else {
 			return $record->Link();
 		}
+	}
+
+	/**
+	 * Find the record to use for a given shortcode.
+	 *
+	 * @param array $args Array of input shortcode arguments
+	 * @param int $errorCode If the file is not found, or is inaccessible, this will be assigned to a HTTP error code.
+	 * @return File|null The File DataObject, if it can be found.
+	 */
+	public static function find_shortcode_record($args, &$errorCode = null) {
+		// Validate shortcode
+		if(!isset($args['id']) || !is_numeric($args['id'])) {
+			$errorCode = 404;
+			return null;
+		}
+
+		// Check if the file is found
+		$file = File::get()->byID($args['id']);
+		if (!$file) {
+			$errorCode = 404;
+			return null;
+		}
+
+		// Check if the file is viewable
+		if(!$file->canView()) {
+			$errorCode = 403;
+			return null;
+		}
+
+		// Success
+		return $file;
+	}
+
+	/**
+	 * Given a HTTP Error, find an appropriate substitute File or SiteTree data object instance.
+	 *
+	 * @param int $errorCode HTTP Error value
+	 * @return File|SiteTree File or SiteTree object to use for the given error
+	 */
+	protected static function find_error_record($errorCode) {
+		$result = static::singleton()->invokeWithExtensions('getErrorRecordFor', $errorCode);
+		$result = array_filter($result);
+		if($result) {
+			return reset($result);
+		}
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
It is necessary to include canView() checks BEFORE invoking getURL(), as getURL() will add this file to that user's whitelist. Later permission checking (at routing) doesn't have the model context available, so it's unable to invoke canView() at that time.
